### PR TITLE
Add service badge for website status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # proWES
 
-[![Apache License](https://img.shields.io/badge/license-Apache%202.0-orange.svg?style=flat&color=important)](http://www.apache.org/licenses/LICENSE-2.0)
+[![Apache License](https://img.shields.io/badge/license-Apache%202.0-blue.svg?style=flat)](http://www.apache.org/licenses/LICENSE-2.0)
 [![Build Status](https://travis-ci.com/elixir-cloud-aai/proWES.svg?branch=dev)](https://travis-ci.com/elixir-cloud-aai/proWES)
+[![Website](https://img.shields.io/website?url=https%3A%2F%2Fprotes.c03.k8s-popup.csc.fi%2Fga4gh%2Ftes%2Fv1%2Fui)](https://protes.c03.k8s-popup.csc.fi/ga4gh/tes/v1/ui/)
 
 See
 [ELIXIR Cloud outline repository](https://github.com/elixir-europe/elixir-cloud-outline)


### PR DESCRIPTION
Service badge shows status of [deployed website](https://protes.c03.k8s-popup.csc.fi/ga4gh/tes/v1/ui/) as either `up` or `down`