### PR TITLE
fix: depricated apiVersion and service field

### DIFF
--- a/deployment/templates/flower/flower-ingress.yaml
+++ b/deployment/templates/flower/flower-ingress.yaml
@@ -2,7 +2,7 @@
 apiVersion: route.openshift.io/v1
 kind: Route
 {{- else }}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 {{ end }}
 metadata:
@@ -31,8 +31,11 @@ status:
   - host: {{ .Values.flower.appName }}.{{ .Values.applicationDomain }}
     http:
       paths:
-      - path: "/"
+      - path: /
+        pathType: Exact
         backend:
-          serviceName: {{ .Values.flower.appName }}
-          servicePort: 5555
+          service:
+            name: {{ .Values.flower.appName }}
+            port:
+              number: 5555
 {{ end }}

--- a/deployment/templates/prowes/prowes-ingress.yaml
+++ b/deployment/templates/prowes/prowes-ingress.yaml
@@ -2,7 +2,7 @@
 apiVersion: route.openshift.io/v1
 kind: Route
 {{- else }}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 {{ end }}
 metadata:
@@ -33,7 +33,10 @@ status:
     http:
       paths:
       - path: "/ga4gh/wes/v1"
+        pathType: Exact
         backend:
-          serviceName: {{ .Values.prowes.appName }}
-          servicePort: 8080
+          service:
+            name: {{ .Values.prowes.appName }}
+            port:
+              number: 8080
 {{ end }}

--- a/deployment/values.yaml
+++ b/deployment/values.yaml
@@ -6,7 +6,7 @@ applicationDomain: rahtiapp.fi
 
 # which cluster type proWES is going to be deployed on
 # it can be either 'kubernetes' or 'openshift'
-clusterType: openshift
+clusterType: kubernetes
 
 flower:
   appName: prowes-flower


### PR DESCRIPTION
**IMPORTANT: Please create an issue before filing a pull request! Changes need to be discussed before proceeding. Please read the [contribution guidelines](CONTRIBUTING.md).**

**Details**

apiVersion for kubernetes `extensions/v1beta1` is no longer in [supported](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/#:~:text=NetworkPolicy%20in%20the%20extensions/v1beta1%20API%20version%20is%20no%20longer%20served) and fixed backend field format.