### PR TITLE
ci: fix broken CI pipeline

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,9 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.10"
+      - name: Pin pip version
+        run: |
+          python -m pip install --upgrade "pip<24.1"
       - name: Install requirements
         run: |
           pip install -r requirements_dev.txt

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           python-version: "3.10"
       - name: Deploy app
-        run: docker-compose up -d --build
+        run: docker compose up -d --build
       - name: Wait for app startup
         run: sleep 20
       - name: Probe endpoint

--- a/pro_wes/ga4gh/wes/workflow_runs.py
+++ b/pro_wes/ga4gh/wes/workflow_runs.py
@@ -482,7 +482,9 @@ class WorkflowRuns:
         """
         dict_of_lists = form_data.to_dict(flat=False)
         # flatten single item lists
-        dict_atomic = {k: v[0] if len(v) == 1 else v for k, v in dict_of_lists.items()}
+        dict_atomic: dict = {
+            k: v[0] if len(v) == 1 else v for k, v in dict_of_lists.items()
+        }
         # remove 'workflow_attachment' field
         dict_atomic.pop("workflow_attachment", None)
         model_instance = RunRequest(**dict_atomic)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 connexion<3
 email-validator>=2.1.0,<3
-foca>=0.12.1
+foca==0.12.1
 gunicorn>=20.1.0,<21


### PR DESCRIPTION
## Summary by Sourcery

Update Docker Compose command, pin pip version to <24.1, and add type hints.

Build:
- Pin pip version to <24.1 in the build process.

Pinning pip version because of dependency resolution issues in CI, since sooner or later this will be revisited and updated with pyproject, that will eventually update all the deps.

Chores:
- Update the Docker Compose command to use the new syntax.
- Add type hints to improve code maintainability.