### PR TITLE
build: update Helm chart

### DIFF
--- a/deployment/Chart.yaml
+++ b/deployment/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: prowes
 description: A proWES Helm chart for Kubernetes
 type: application
-version: 0.1.0
-appVersion: 1.16.0
+version: 2.0.0
+appVersion: 2.0.0

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -3,8 +3,6 @@
 - [Kubernetes deployment for proWES](#kubernetes-deployment-for-wes)
     - [Usage](#usage)
         - [Updates](#updates)
-        - [Using with an external MongoDB](#using-with-an-external-mongodb)
-        - [Setting up RabbitMQ for testing on OpenShift](#setting-up-rabbitmq-for-testing-on-openshift)
     - [Technical details](#technical-details)
         - [MongoDB](#mongodb)
         - [RabbitMQ](#rabbitmq)
@@ -53,36 +51,22 @@ Create a Kubernetes Secret from the `.netrc` file:
 kubectl create secret generic netrc --from-file .netrc
 ```
 
-After this you can deploy proWES using `kubectl`:
+You need to edit the `values.yaml` file to specify your `applicationDomain` and the `clusterType`
+
+After this you can deploy proWES using `helm`:
 
 ```bash
-cd deployment/common/wes
-ls wes-* | xargs -L1 kubectl create -f
-```
-
-Once proWES is deployed, you can expose it with the YAML files found under
-`deployment/ingress`. Which file to use depends on your cluster and how ingress
-is configured there.
-
-Creating an OpenShift Route:
-
-```bash
-cd deployment/ingress
-oc create -f wes-route.yaml
+helm install prowes . -f values.yaml
 ```
 
 ### Updates
 
-If you make changes to any of the Deployments, you can update them with
-`kubectl`. For example, this is how you would update the Celery worker Deployment:
+If you want to edit any of the Deployments, you can update them with
+`helm` and the `values.yaml` file. Once edited, you can run this command:
 
 ```bash
-kubectl replace -f wes-celery-deployment.yaml
+helm upgrade prowes . -f values.yaml
 ```
-
-The OpenShift specific objects need to be updated using the `oc` tool instead.
-Also, if you update the Route you must use the `--force` flag. This removes and
-recreates the Route.
 
 If you want to point to a different FTP server or change the login credentials
 for the current FTP server, you can update the `.netrc` secret like so:
@@ -91,67 +75,7 @@ for the current FTP server, you can update the `.netrc` secret like so:
 kubectl create secret generic netrc --from-file .netrc --dry-run -o yaml | kubectl apply -f -
 ```
 
-If you want to update the configuration, you can update the ConfigMap or use a
-different ConfigMap with the same name. The Deployments expect to find the
-`app_config.yaml` ConfigMap with the name `wes-config`. You can update the
-ConfigMap like so:
-
-```bash
-kubectl replace -f wes-configmap.yaml
-```
-
-### Using with an external MongoDB
-
-In certain situations, you may want to run an external MongoDB. There is an
-example headless service file for this case under `deployment/mongodb`.
-
-Make a copy of the example Service:
-
-```bash
-cd deployment/mongodb
-cp mongodb-service-external.yaml.example mongodb-service-external.yaml
-```
-
-Edit the `mongodb-service-external.yaml` file and under `externalName` add your
-external MongoDB's host name. After this, create the Service:
-
-```bash
-kubectl create -f mongodb-service-external.yaml
-```
-
-It is assumed that the external MongoDB already has a database called
-`prowes-db` created and a user with read-write access available. Next you
-will need to configure the MongoDB user and password in a secret (replace
-`<username>` and `<password>`):
-
-```bash
-kubectl create secret generic mongodb --from-literal=database-user=<username> --from-literal=database-password=<password>
-```
-
-Depending on your MongoDB provider, the port may differ from 27017. In this
-case, you will need to modify the Deployment files accordingly to use the
-correct port (replace `<my external mongodb port>`):
-
-```bash
-cd deployment/common
-find . -name *.yaml | xargs -L1 sed -i -e 's/27017/<my external mongodb port>/g'
-```
-
-After this you can deploy proWES (see above).
-
 ## Technical details
-
-### ApplicaWES
-
-proWES consists of five deployments: a Flask server and a Celery worker. These
-are deployed using:
-
-- `templates/prowes/prowes-deployment.yaml`
-- `templates/prowes/celery-deployment.yaml`
-
-These deployments depend on setting up a shared ReadWriteMany volume between
-Flask and Celery (`wes-volume.yaml`) and a shared ConfigMap
-(`wes-configmap.yaml`).
 
 ### MongoDB
 
@@ -166,6 +90,23 @@ is deployed using:
 
 - `templates/rabbitmq/rabbitmq-deployment.yaml`
 
-The disadvantage with this template is that it only works with OpenShift because
-it uses objects that are only available in OpenShift. For plain Kubernetes a
-different approach needs to be used.
+### WES
+
+proWES consists of five deployments: a Flask server and a Celery worker. These
+are deployed using:
+
+- `templates/prowes/prowes-deployment.yaml`
+- `templates/prowes/celery-deployment.yaml`
+
+These deployments depend on setting up a shared ReadWriteMany volume between
+(`wes-configmap.yaml`).
+
+
+## Destroy
+
+Simply run:
+
+```bash
+helm uninstall prowes
+```
+

--- a/deployment/templates/NOTES.txt
+++ b/deployment/templates/NOTES.txt
@@ -8,4 +8,4 @@ Once deployed:
 
        curl -X GET "https://{{ .Values.prowes.appName }}.{{ .Values.applicationDomain }}/ga4gh/wes/v1/service-info" -H "Accept: application/json"
 
-  2. Access the Swagger UI via https://{{ .Values.prowes.appName }}/ga4gh/wes/v1/ui
+  2. Access the Swagger UI via https://{{ .Values.prowes.appName }}.{{ .Values.applicationDomain }}/ga4gh/wes/v1/ui

--- a/deployment/templates/NOTES.txt
+++ b/deployment/templates/NOTES.txt
@@ -1,0 +1,11 @@
+Elixir Cloud proWES is being deployed!
+
+Once deployed:
+
+  1. Access the API via https://{{ .Values.prowes.appName }}.{{ .Values.applicationDomain }}/ga4gh/wes/v1/
+
+     To test the connection, you can run:
+
+       curl -X GET "https://{{ .Values.prowes.appName }}.{{ .Values.applicationDomain }}/ga4gh/wes/v1/service-info" -H "Accept: application/json"
+
+  2. Access the Swagger UI via https://{{ .Values.prowes.appName }}/ga4gh/wes/v1/ui

--- a/deployment/templates/flower/flower-deployment.yaml
+++ b/deployment/templates/flower/flower-deployment.yaml
@@ -19,3 +19,4 @@ spec:
         command: ['flower']
         args: ['--broker=amqp://guest:guest@rabbitmq:5672//', '--port=5555', '--basic_auth={{ .Values.flower.basicAuth }}']
         name: flower
+        resources: {{- toYaml .Values.flower.resources | nindent 10 }}

--- a/deployment/templates/mongodb/mongo-init-script.yaml
+++ b/deployment/templates/mongodb/mongo-init-script.yaml
@@ -1,0 +1,41 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mongo-init-script 
+data:
+  init-script.js: |
+    db = db.getSiblingDB('runStore');
+    dbproWES = db.getSiblingDB('{{ tpl .Values.mongodb.secret.databaseName . }}')
+
+    dbproWES.createUser({
+      user: "{{ tpl .Values.mongodb.secret.databaseUser . }}",
+      pwd: "{{ tpl .Values.mongodb.secret.databasePassword . }}",
+      roles: [
+        {
+          role: "readWrite",
+          db: "{{ tpl .Values.mongodb.secret.databaseName . }}"
+        }
+      ]
+    });
+
+    // Create the 'runs' and 'service_info' collections
+    // Database configuration from https://github.com/elixir-cloud-aai/proWES/blob/59b53a4bdd06dd83ff41754b27d97309073ed237/pro_wes/config.yaml#L30
+    db.createCollection('runs');
+    db.runs.createIndex(
+      { run_id: 1, task_id: 1 },
+      { unique: true, sparse: true }
+    );
+    db.createCollection('service_info');
+    db.service_info.createIndex(
+      { id: 1 }
+    );
+
+    dbproWES.createCollection('runs');
+    dbproWES.runs.createIndex(
+      { run_id: 1, task_id: 1 },
+      { unique: true, sparse: true }
+    );
+    dbproWES.createCollection('service_info');
+    dbproWES.service_info.createIndex(
+      { id: 1}
+    );

--- a/deployment/templates/mongodb/mongodb-deployment.yaml
+++ b/deployment/templates/mongodb/mongodb-deployment.yaml
@@ -64,9 +64,7 @@ spec:
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1
-          resources:
-            limits:
-              memory: 512Mi
+          resources: {{- toYaml .Values.mongodb.resources | nindent 10 }}
           volumeMounts:
             - mountPath: /var/lib/mongodb/data
               name: mongodb-data

--- a/deployment/templates/mongodb/mongodb-deployment.yaml
+++ b/deployment/templates/mongodb/mongodb-deployment.yaml
@@ -16,25 +16,30 @@ spec:
     spec:
       containers:
         - env:
-          - name: MONGODB_USER
+          - name: MONGO_INITDB_ROOT_USERNAME
             valueFrom:
               secretKeyRef:
-                key: database-user
+                key: databaseRootUsername
                 name: {{ .Values.mongodb.appName }}
-          - name: MONGODB_PASSWORD
+          - name: MONGO_INITDB_ROOT_PASSWORD
             valueFrom:
               secretKeyRef:
-                key: database-password
+                key: databaseRootPassword
                 name: {{ .Values.mongodb.appName }}
-          - name: MONGODB_ADMIN_PASSWORD
+          - name: MONGO_INITDB_DATABASE
             valueFrom:
               secretKeyRef:
-                key: database-admin-password
+                key: databaseName
                 name: {{ .Values.mongodb.appName }}
-          - name: MONGODB_DATABASE
+          - name: MONGO_APP_USERNAME
             valueFrom:
               secretKeyRef:
-                key: database-name
+                key: databaseUser
+                name: {{ .Values.mongodb.appName }}
+          - name: MONGO_APP_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: databasePassword
                 name: {{ .Values.mongodb.appName }}
           image: {{ .Values.mongodb.image }}
           imagePullPolicy: IfNotPresent
@@ -57,18 +62,23 @@ spec:
                 - '-i'
                 - '-c'
                 - >-
-                  mongo 127.0.0.1:27017/$MONGODB_DATABASE -u $MONGODB_USER -p
-                  $MONGODB_PASSWORD --eval="quit()"
+                  mongosh --host 127.0.0.1:27017 -u $MONGO_INITDB_ROOT_USERNAME -p $MONGO_INITDB_ROOT_PASSWORD --authenticationDatabase admin $MONGO_INITDB_DATABASE --eval="quit()"
             failureThreshold: 3
-            initialDelaySeconds: 3
+            initialDelaySeconds: 30
             periodSeconds: 10
             successThreshold: 1
-            timeoutSeconds: 1
-          resources: {{- toYaml .Values.mongodb.resources | nindent 10 }}
+            timeoutSeconds: 50
+          resources: {{- toYaml .Values.mongodb.resources | nindent 12 }}
           volumeMounts:
-            - mountPath: /var/lib/mongodb/data
+            - mountPath: /data/db
               name: mongodb-data
+            - name: init-script
+              mountPath: /docker-entrypoint-initdb.d/init-script.js
+              subPath: init-script.js
       volumes:
         - name: mongodb-data
           persistentVolumeClaim:
             claimName: {{ .Values.mongodb.appName }}-volume
+        - name: init-script
+          configMap:
+            name: mongo-init-script

--- a/deployment/templates/mongodb/mongodb-pvc.yaml
+++ b/deployment/templates/mongodb/mongodb-pvc.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ .Values.mongodb.appName }}-volume
 spec:
   accessModes:
-    - ReadWriteMany
+    - {{ .Values.storageAccessMode }}
   resources:
     requests:
       storage: {{ .Values.mongodb.volumeSize }}

--- a/deployment/templates/mongodb/mongodb-secret.yaml
+++ b/deployment/templates/mongodb/mongodb-secret.yaml
@@ -4,7 +4,7 @@ type: Opaque
 metadata:
   name: {{ .Values.mongodb.appName }}
 data:
-  database-admin-password: {{ .Values.mongodb.databaseAdminPassword  | b64enc }}
-  database-name: {{ .Values.mongodb.databaseName  | b64enc }}
-  database-password: {{ .Values.mongodb.databasePassword  | b64enc }}
-  database-user: {{ .Values.mongodb.databaseUser  | b64enc }}
+  {{- range $key, $val := .Values.mongodb.secret }}
+    "{{ $key }}": "{{ tpl $val $ | b64enc }}"
+  {{- end }}
+

--- a/deployment/templates/prowes/celery-deployment.yaml
+++ b/deployment/templates/prowes/celery-deployment.yaml
@@ -35,17 +35,17 @@ spec:
         - name: MONGO_USERNAME
           valueFrom:
             secretKeyRef:
-              key: database-user
+              key: databaseUser
               name: {{ .Values.mongodb.appName }}
         - name: MONGO_PASSWORD
           valueFrom:
             secretKeyRef:
-              key: database-password
+              key: databasePassword
               name: {{ .Values.mongodb.appName }}
         - name: MONGO_DBNAME
           valueFrom:
             secretKeyRef:
-              key: database-name
+              key: databaseName
               name: {{ .Values.mongodb.appName }}
         - name: RABBIT_HOST
           value: {{ .Values.rabbitmq.appName }}

--- a/deployment/templates/prowes/celery-deployment.yaml
+++ b/deployment/templates/prowes/celery-deployment.yaml
@@ -16,6 +16,13 @@ spec:
         image: busybox
         command: [ 'mkdir' ]
         args: [ '-p', '/data/db', '/data/output', '/data/tmp' ]
+        resources:
+          limits:
+            memory: 256Mi
+            cpu: 100m
+          requests:
+            memory: 256Mi
+            cpu: 100m
         volumeMounts:
         - mountPath: /data
           name: prowes-volume
@@ -50,13 +57,7 @@ spec:
           value: {{ .Values.rabbitmq.appName }}
         - name: RABBIT_PORT
           value: "5672"
-        resources:
-          requests:
-            memory: "512Mi"
-            cpu: "300m"
-          limits:
-            memory: "8Gi"
-            cpu: "1"
+        resources: {{- toYaml .Values.celeryWorker.resources | nindent 10 }}
         volumeMounts:
         - mountPath: /data
           name: prowes-volume

--- a/deployment/templates/prowes/celery-deployment.yaml
+++ b/deployment/templates/prowes/celery-deployment.yaml
@@ -16,13 +16,7 @@ spec:
         image: busybox
         command: [ 'mkdir' ]
         args: [ '-p', '/data/db', '/data/output', '/data/tmp' ]
-        resources:
-          limits:
-            memory: 256Mi
-            cpu: 100m
-          requests:
-            memory: 256Mi
-            cpu: 100m
+        resources: {{- toYaml .Values.celeryWorker.initResources | nindent 10 }}
         volumeMounts:
         - mountPath: /data
           name: prowes-volume

--- a/deployment/templates/prowes/prowes-deployment.yaml
+++ b/deployment/templates/prowes/prowes-deployment.yaml
@@ -48,17 +48,17 @@ spec:
         - name: MONGO_USERNAME
           valueFrom:
             secretKeyRef:
-              key: database-user
+              key: databaseUser
               name: {{ .Values.mongodb.appName }}
         - name: MONGO_PASSWORD
           valueFrom:
             secretKeyRef:
-              key: database-password
+              key: databasePassword
               name: {{ .Values.mongodb.appName }}
         - name: MONGO_DBNAME
           valueFrom:
             secretKeyRef:
-              key: database-name
+              key: databaseName
               name: {{ .Values.mongodb.appName }}
         - name: RABBIT_HOST
           value: {{ .Values.rabbitmq.appName }}

--- a/deployment/templates/prowes/prowes-deployment.yaml
+++ b/deployment/templates/prowes/prowes-deployment.yaml
@@ -12,11 +12,24 @@ spec:
       labels:
         app: {{ .Values.prowes.appName }}
     spec:
+      {{- if eq .Values.storageAccessMode "ReadWriteOnce" }}
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - {{ .Values.celeryWorker.appName }}
+            topologyKey: "kubernetes.io/hostname"
+      {{- end }}
       initContainers:
       - name: vol-init
         image: busybox
         command: [ 'mkdir' ]
         args: [ '-p', '/data/db', '/data/specs' ]
+        resources: {{- toYaml .Values.prowes.resources | nindent 10 }}
         volumeMounts:
         - mountPath: /data
           name: prowes-volume
@@ -51,6 +64,13 @@ spec:
           value: {{ .Values.rabbitmq.appName }}
         - name: RABBIT_PORT
           value: "5672"
+        resources:
+          limits:
+            cpu: 500m
+            memory: 256Mi
+          requests:
+            cpu: 100m
+            memory: 256Mi
         livenessProbe:
           tcpSocket:
             port: prowes-port

--- a/deployment/templates/prowes/prowes-deployment.yaml
+++ b/deployment/templates/prowes/prowes-deployment.yaml
@@ -29,7 +29,7 @@ spec:
         image: busybox
         command: [ 'mkdir' ]
         args: [ '-p', '/data/db', '/data/specs' ]
-        resources: {{- toYaml .Values.prowes.resources | nindent 10 }}
+        resources: {{- toYaml .Values.prowes.initResources | nindent 10 }}
         volumeMounts:
         - mountPath: /data
           name: prowes-volume
@@ -64,13 +64,7 @@ spec:
           value: {{ .Values.rabbitmq.appName }}
         - name: RABBIT_PORT
           value: "5672"
-        resources:
-          limits:
-            cpu: 500m
-            memory: 256Mi
-          requests:
-            cpu: 100m
-            memory: 256Mi
+        resources: {{- toYaml .Values.prowes.resources | nindent 10 }}
         livenessProbe:
           tcpSocket:
             port: prowes-port

--- a/deployment/templates/prowes/prowes-volume.yaml
+++ b/deployment/templates/prowes/prowes-volume.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ .Values.prowes.appName}}-volume
 spec:
   accessModes:
-    - ReadWriteMany
+    - {{ .Values.storageAccessMode }}
   resources:
     requests:
       storage: '1Gi'

--- a/deployment/templates/rabbitmq/rabbitmq-deployment.yaml
+++ b/deployment/templates/rabbitmq/rabbitmq-deployment.yaml
@@ -17,6 +17,7 @@ spec:
       containers:
       - name: rabbitmq
         image: {{ .Values.rabbitmq.image }}
+        resources: {{- toYaml .Values.rabbitmq.resources | nindent 10 }}
         volumeMounts:
         - mountPath: /var/lib/rabbitmq
           name: rabbitmq-volume

--- a/deployment/templates/rabbitmq/rabbitmq-pvc.yaml
+++ b/deployment/templates/rabbitmq/rabbitmq-pvc.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ .Values.rabbitmq.appName }}-volume
 spec:
   accessModes:
-    - ReadWriteMany
+    - {{ .Values.storageAccessMode }}
   resources:
     requests:
       storage: {{ .Values.rabbitmq.volumeSize }}

--- a/deployment/values.yaml
+++ b/deployment/values.yaml
@@ -25,6 +25,13 @@ flower:
 prowes:
   appName: prowes
   image: elixircloud/prowes:latest
+  initResources:
+    limits:
+      memory: 16Mi
+      cpu: 10m
+    requests:
+      memory: 16Mi
+      cpu: 10m
   resources:
     limits:
       memory: 256Mi
@@ -36,6 +43,13 @@ prowes:
 celeryWorker:
   appName: celery-worker
   image: elixircloud/prowes:latest
+  initResources:
+    limits:
+      memory: 16Mi
+      cpu: 10m
+    requests:
+      memory: 16Mi
+      cpu: 10m
   resources:
     limits:
       cpu: 500m

--- a/deployment/values.yaml
+++ b/deployment/values.yaml
@@ -28,10 +28,10 @@ prowes:
   initResources:
     limits:
       memory: 16Mi
-      cpu: 10m
+      cpu: 50m
     requests:
       memory: 16Mi
-      cpu: 10m
+      cpu: 50m
   resources:
     limits:
       memory: 256Mi
@@ -46,10 +46,10 @@ celeryWorker:
   initResources:
     limits:
       memory: 16Mi
-      cpu: 10m
+      cpu: 50m
     requests:
       memory: 16Mi
-      cpu: 10m
+      cpu: 50m
   resources:
     limits:
       cpu: 500m

--- a/deployment/values.yaml
+++ b/deployment/values.yaml
@@ -2,24 +2,47 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-applicationDomain: rahtiapp.fi
+applicationDomain: ""
 
 # which cluster type proWES is going to be deployed on
 # it can be either 'kubernetes' or 'openshift'
 clusterType: kubernetes
 
+# mongodb-pvc.yaml/rabbitmq-pvc.yaml, change to ReadWriteMany if storageClass can do RWX
+storageAccessMode: ReadWriteOnce
+
 flower:
   appName: prowes-flower
   basicAuth: admin:admin
   image: endocode/flower
-
+  resources:
+    limits:
+      cpu: 500m
+      memory: 1Gi
+    requests:
+      cpu: 300m
+      memory: 500Mi
 prowes:
   appName: prowes
   image: elixircloud/prowes:latest
+  resources:
+    limits:
+      memory: 256Mi
+      cpu: 100m
+    requests:
+      memory: 256Mi
+      cpu: 100m
 
 celeryWorker:
   appName: celery-worker
   image: elixircloud/prowes:latest
+  resources:
+    limits:
+      cpu: 500m
+      memory: 256Mi
+    requests:
+      cpu: 100m
+      memory: 256Mi
 
 mongodb:
   appName: mongodb
@@ -29,8 +52,23 @@ mongodb:
   databaseUser: prowes-user
   volumeSize: 1Gi
   image: centos/mongodb-36-centos7
+  resources:
+    limits:
+      cpu: 500m
+      memory: 512Mi
+    requests:
+      cpu: 500m
+      memory: 512Mi
 
 rabbitmq:
   appName: rabbitmq
   volumeSize: 1Gi
   image: rabbitmq:3-management
+  resources:
+    limits:
+      cpu: 500m
+      memory: 1Gi
+    requests:
+      cpu: 500m
+      memory: 256Mi
+

--- a/deployment/values.yaml
+++ b/deployment/values.yaml
@@ -17,10 +17,10 @@ flower:
   image: endocode/flower
   resources:
     limits:
-      cpu: 500m
+      cpu: 200m
       memory: 1Gi
     requests:
-      cpu: 300m
+      cpu: 200m
       memory: 500Mi
 prowes:
   appName: prowes
@@ -52,7 +52,7 @@ celeryWorker:
       cpu: 50m
   resources:
     limits:
-      cpu: 500m
+      cpu: 200m
       memory: 256Mi
     requests:
       cpu: 100m
@@ -65,24 +65,24 @@ mongodb:
   databasePassword: prowes-db-passwd
   databaseUser: prowes-user
   volumeSize: 1Gi
-  image: centos/mongodb-36-centos7
+  image: docker.io/library/mongo:noble 
   resources:
     limits:
-      cpu: 500m
+      cpu: 200m
       memory: 512Mi
     requests:
-      cpu: 500m
+      cpu: 200m
       memory: 512Mi
 
 rabbitmq:
   appName: rabbitmq
   volumeSize: 1Gi
-  image: rabbitmq:3-management
+  image: rabbitmq:4.1.4-management
   resources:
     limits:
-      cpu: 500m
+      cpu: 200m
       memory: 1Gi
     requests:
-      cpu: 500m
+      cpu: 200m
       memory: 256Mi
 

--- a/deployment/values.yaml
+++ b/deployment/values.yaml
@@ -2,11 +2,11 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-applicationDomain: "rahtiapp.fi"
+applicationDomain: ""
 
 # which cluster type proWES is going to be deployed on
 # it can be either 'kubernetes' or 'openshift'
-clusterType: openshift 
+clusterType: kubernetes
 
 # mongodb-pvc.yaml/rabbitmq-pvc.yaml, change to ReadWriteMany if storageClass can do RWX
 storageAccessMode: ReadWriteOnce
@@ -61,13 +61,13 @@ celeryWorker:
 mongodb:
   appName: mongodb
   secret:
-    databaseRootUsername: prowes-adm
-    databaseRootPassword: adminpasswd
-    databaseUser: prowes-user
-    databasePassword: prowes-db-passwd
-    databaseName: prowes-db
+    databaseRootUsername: ""
+    databaseRootPassword: ""
+    databaseUser: ""
+    databasePassword: ""
+    databaseName: ""
   volumeSize: 1Gi
-  image: docker.io/library/mongo:noble 
+  image: docker.io/library/mongo:noble
   resources:
     limits:
       cpu: 200m

--- a/deployment/values.yaml
+++ b/deployment/values.yaml
@@ -2,11 +2,11 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-applicationDomain: ""
+applicationDomain: "rahtiapp.fi"
 
 # which cluster type proWES is going to be deployed on
 # it can be either 'kubernetes' or 'openshift'
-clusterType: kubernetes
+clusterType: openshift 
 
 # mongodb-pvc.yaml/rabbitmq-pvc.yaml, change to ReadWriteMany if storageClass can do RWX
 storageAccessMode: ReadWriteOnce
@@ -60,10 +60,12 @@ celeryWorker:
 
 mongodb:
   appName: mongodb
-  databaseAdminPassword: adminpasswd
-  databaseName: prowes-db
-  databasePassword: prowes-db-passwd
-  databaseUser: prowes-user
+  secret:
+    databaseRootUsername: prowes-adm
+    databaseRootPassword: adminpasswd
+    databaseUser: prowes-user
+    databasePassword: prowes-db-passwd
+    databaseName: prowes-db
   volumeSize: 1Gi
   image: docker.io/library/mongo:noble 
   resources:


### PR DESCRIPTION
- Add resources
- Add a key to change the storage mode
  - if RWO, the prowes pods will be deployed on the same nodes
  - Update mongo to noble
    - Add init-script.js configMap
    - Update secrets
    - Update env
  - Update rabbitMQ to 4.1.4-management

**IMPORTANT: Please create an issue before filing a pull request! Changes need to be discussed before proceeding. Please read the [contribution guidelines](CONTRIBUTING.md).**

**Details**

Please provide enough information so that others can review your pull request. Give a brief summary of the motivation. Refer to the corresponding issue/s with `#XXXX` for more information.

**Testing**

Write the appropriate unit and integration tests, if applicable. Make sure these and all other tests pass.

**Documentation**

Please document your changes and test cases in the appropriate places, if applicable.

**Style**

Make sure your changes adhere to the coding/documentation style used throughout the project.

**Closing issues**

If your changes fix any issue/s, put `closes #XXXX` in your comment to auto-close it/them.

**Credit**

Add your credentials to the [list of contributors](contributors.md) once your pull request was merged.

## Summary by Sourcery

Add storageAccessMode option for PVCs, configure resource requests and limits across all services, and implement pod affinity for ReadWriteOnce deployments

New Features:
- Introduce storageAccessMode configuration to toggle PVC accessModes between ReadWriteOnce and ReadWriteMany

Enhancements:
- Add configurable resource requests and limits for flower, prowes, celeryWorker, mongodb, and rabbitmq
- Implement pod affinity for prowes when using ReadWriteOnce to co-locate pods on the same node
- Update PVC and volume templates to respect the storageAccessMode value
- Refactor deployment templates to use toYaml for centralized resource definitions